### PR TITLE
Åtkomstkontroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.settings/
+/.project

--- a/Grupper.gs
+++ b/Grupper.gs
@@ -19,6 +19,7 @@ function GrupperRubrikData() {
   gruppRubrikData["synk_option"] = 3;
   gruppRubrikData["groupId"] = 4;
   gruppRubrikData["cell_url"] = 5;
+  gruppRubrikData["post_permission"] = 6;
                   
   return gruppRubrikData;
 }
@@ -41,10 +42,14 @@ function Grupper() {
     var scoutnet_list_id = data[i][grd["scoutnet_list_id"]];
     var synk_option = data[i][grd["synk_option"]];
     var groupId = data[i][grd["groupId"]];
+    var postPermission = data[i][grd["post_permission"]];
+    if (!postPermission) {
+      postPermission = "ANYONE_CAN_POST";
+    }
     
     var rad_nummer = i+1;
     
-    Logger.log('Namn: ' + name + ' E-post: ' + email + ' Scoutnet: ' + scoutnet_list_id + ' grupp id: ' + groupId);
+    Logger.log('Namn: ' + name + ' E-post: ' + email + ' Scoutnet: ' + scoutnet_list_id + ' Grupp-ID: ' + groupId + ' Inläggsbehörighet: ' + postPermission);
     
     var update_group = "yes";
     
@@ -68,7 +73,7 @@ function Grupper() {
           email = email.toLowerCase().replace(/\s+/g, ''); //Ta bort tomma mellanrum
           email = removeDiacritics(email);
           
-          var group = createGroup(email, name);   
+          var group = createGroup(email, name);
           var groupId = group.id;
           Logger.log("Skapade gruppen: " + email);
           
@@ -144,7 +149,7 @@ function Grupper() {
             var cell=selection.getCell(rad_nummer, grd["e-post"]+1);
             cell.setBackground("red");
           }
-        }        
+        }
         else if (name != group.name) { //Om namnet, men inte e-postadressen för gruppen ändrats
           
           Logger.log("Gruppnamnet har ändrats på rad " + rad_nummer);
@@ -160,12 +165,13 @@ function Grupper() {
           cell.setBackground("white");
         }
       }
-    }    
+    }
     if (update_group == "yes") {
       var cell_scoutnet_list_id = selection.getCell(rad_nummer, grd["scoutnet_list_id"]+1);
       updateGroup(groupId, scoutnet_list_id, cell_scoutnet_list_id, synk_option); //Uppdatera medlemmar av en grupp
     }
-  }  
+    changeGroupPermissions(email, postPermission);
+  }
   deleteRowsFromSpreadsheet(sheet, delete_rows);
 }
 
@@ -220,8 +226,7 @@ function createGroup(email, name) {
     "description": "Scoutnet"
   };
             
-  AdminDirectory.Groups.insert(tmp_group);        
-  changeGroupPermissions(email);
+  AdminDirectory.Groups.insert(tmp_group);
             
   var group = AdminDirectory.Groups.get(email);
   
@@ -379,7 +384,7 @@ function addGroupMember(groupId, email) {
  *
  * @param {string} email - E-postadress för en grupp
  */
-function changeGroupPermissions(email) {
+function changeGroupPermissions(email, postPermission) {
   
   var group = AdminGroupsSettings.newGroups();
   
@@ -388,7 +393,7 @@ function changeGroupPermissions(email) {
   group.whoCanInvite = 'ALL_MANAGERS_CAN_INVITE';
   group.whoCanAdd = 'ALL_MANAGERS_CAN_ADD';
   group.allowExternalMembers = true;
-  group.whoCanPostMessage = 'ANYONE_CAN_POST';
+  group.whoCanPostMessage = postPermission;
   group.primaryLanguage = 'sv';
   group.messageModerationLevel = 'MODERATE_NONE';
   group.replyTo = 'REPLY_TO_SENDER';
@@ -412,11 +417,11 @@ function createHeaders_Grupper() {
   
   // Våra värden vi vill ha som rubriker för de olika kolumnerna
   var values = [
-    ["Namn", "E-post", "Scoutnet-id", "Synkinställning", "grupp id hos Google RÖR EJ", "Länk"]
+    ["Namn", "E-post", "Scoutnet-id", "Synkinställning", "Grupp-ID hos Google (RÖR EJ)", "Länk", "Begränsa åtkomst (valfritt)"]
   ];
 
   // Sätter området för cellerna som vi ska ändra
-  var range = sheet.getRange("A1:F1");
+  var range = sheet.getRange("A1:G1");
 
   // Sätter våra rubriker på vårt område
   range.setValues(values); 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,17 @@ Det går också att ställa in i detta fält vilka e-postadressfält från scout
 Det går att enkelt kontrollera vilka som är med i en google-grupp genom att trycka på länken vid varje e-postadress i kalkylarket.
 
 Om du vill att en person ska vara med i en Google-grupp utan att beröras av att tas bort vid en synkronisering lägger du till e-postadressen som ägare eller medarbetare av gruppen.
+
+#### Begränsa åtkomst
+
+Kolumnen "Begränsa åtkomst" i kalkylbladet styr vem som får lov att skicka till listan. Detta kan t.ex. användas så att bara ledare inom kåren får lov att skicka till listor med alla scouter, medan en lista som går till ledarna kan användas av utomstående.
+
+- Tom ruta betyder betyder att vem som helst får skicka till listan. Detta är bra för inkommande meddelanden, t.ex. styrelsen, ledarteam, lägerkommittéer osv.
+- "ALL_IN_DOMAIN_CAN_POST" begränsar till avsändare från kårens domän i G Suite. Detta är bra för listor som går till alla scouter på en avdelning eller hela kåren.
+- För mer info, se avsnittet "whoCanPostMessage" i Googles dokumentation här: https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups#resource
+
 #### Inställningar (i Konfiguration.gs)
-- Ändra kårens domän namn på variabeln "domain"
+- Ändra kårens domännamn på variabeln "domain"
 - Ändra kårens grupp-id som finns angivet i Scoutnet på sidan för Webbkoppling
 - Ändra api-nyckeln med namn api_key_mailinglists som hittas i Scoutnet under Webbkoppling under "Get a csv/xls/json list of members, based on mailing lists you have set up"
 - Skapa ett Google Kalkylark och klistra in webbadressen vid variabeln "spreadsheetUrl_Grupper"


### PR DESCRIPTION
Behörigheten att skicka kan ställas in via kalkylarket. Standardvärdet är fortfarande ANYONE_CAN_POST, men jag använder t.ex. ALL_IN_DOMAIN_CAN_POST för utgående listor till barn och föräldrar.