### PR TITLE
Uppdaterad tabell, ändrad beskrivning för Google Team Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,41 @@ Om du saknar något exempel eller behöver hjälp är det bara att mejla emil.oh
       
    Gör följande inställningar i kalkylarket
 
-	| Kan skicka och ta emot | Synkinställning | Kan skicka              | Synkinställning | Kan ta emot               |                 |
-	|------------------------|-----------------|-------------------------|-----------------|---------------------------|-----------------|
-	| Scoutnet-id            | Synkinställning | Scoutnet-id             | Synkinställning | Scoutnet-id               | Synkinställning |
-	|                        |                 | @ (kårens googlekonton) |                 | 1910 (id för avdelningen) |                 |
-   
+   <table>
+      <thead>
+         <tr>
+            <th colspan=2>Kan skicka och ta emot</th>
+            <th colspan=2>Kan skicka</th>
+            <th colspan=2>Kan ta emot</th>
+         </tr>
+      </thead>
+      <tbody>
+         <tr>
+            <td>Scoutnet-id</td>
+            <td>Synkinställning</td>
+            <td>Scoutnet-id</td>
+            <td>Synkinställning</td>
+            <td>Scoutnet-id</td>
+            <td>Synkinställning</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td></td>
+            <td>@ (kårens googlekonton)</td>
+            <td></td>
+            <td>1910 (id för avdelningen)</td>
+            <td></td>
+         </tr>
+      </tbody>
+   </table>
+
+#### Google Team Drive - exempel
+Att koppla ihop grupper med delade enheter på Google Team Drive sker manuellt, men du kan använda grupperna som skapats enligt ovan för enkel uppdatering av åtkomst.
+Om du döper om själva gruppen, t.ex. e-postadressen, _kan_ gruppen tappa åtkomst till mappen.
+
+- Skapa en "Delad enhet" på Google Drive (https://drive.google.com) från ett konto med lämplig behörighet
+- Lägg till medlemmar till den delade enheten, du kan använda grupper som skapats ovan
+
 ### Felmeddelanden och förslag till lösning
 *  ```
    API-anrop till directory.users.insert misslyckades med felet: Domain user limit reached......


### PR DESCRIPTION
Tabellen i exemplet för grupper var lite otydlig eftersom rubrikerna i kalkylarket tar två kolumner. Den är därför omskriven med HTML för att stämma bättre med hur det ser ut i dokumentet.

Jag flyttade även om texten för Google Team Drive, så den här ersätter tidigare PR #14 